### PR TITLE
Aggregat all spec files to main_.spec file.

### DIFF
--- a/specs/main_.spec
+++ b/specs/main_.spec
@@ -6,14 +6,54 @@ main_dir = os.path.dirname(main_dir)
 
 block_cipher = None
 
+def analysis(_spec_path_list, _pathex, _datas, _hiddenimports, _name):
+    """
+    Do analyized spec file and get analyized data and exe binary data.
+    """
+
+    print(f'##### Analyzed {_spec_path_list} #####')
+
+    a = Analysis(_spec_path_list,
+                 pathex=_pathex,
+                 binaries=[],
+                 datas=_datas,
+                 hiddenimports=_hiddenimports,
+                 hookspath=[],
+                 runtime_hooks=[],
+                 excludes=[],
+                 win_no_prefer_redirects=False,
+                 win_private_assemblies=False,
+                 cipher=block_cipher)
+
+    pyz = PYZ(a.pure, a.zipped_data,
+                 cipher=block_cipher)
+    exe = EXE(pyz,
+              a.scripts,
+              exclude_binaries=True,
+              name=_name,
+              debug=False,
+              strip=False,
+              upx=True,
+              console=True )
+
+#    coll = COLLECT(exe, a.binaries, a.zipfiles, a.datas, strip=False, upx=True, name='main')
+
+    return (exe, a.binaries, a.zipfiles, a.datas) 
+
+
+coll = ()
+
+########################## main ##########################
 pathex=[
-				main_dir,
-				path.join(main_dir, "filesystem"),
-				path.join(main_dir, "dojo"),
-				path.join(main_dir, "annotator"),
-				path.join(main_dir, "gui"),
-				path.join(main_dir, "plugins"),
-				path.join(main_dir, "segment")]
+  main_dir,
+  path.join(main_dir, "filesystem"),
+  path.join(main_dir, "dojo"),
+  path.join(main_dir, "annotator"),
+  path.join(main_dir, "gui"),
+  path.join(main_dir, "plugins"),
+  path.join(main_dir, "segment")
+]
+
 for dirpath, dirnames, filenames in os.walk( path.join(main_dir, "plugins") ):
     if os.path.basename(dirpath) != '__pycache__':
             pathex.append(path.join(main_dir, "plugins", dirpath))
@@ -22,43 +62,101 @@ for dirpath, dirnames, filenames in os.walk( path.join(main_dir, "segment") ):
     if os.path.basename(dirpath) != '__pycache__':
             pathex.append(path.join(main_dir, "segment", dirpath))
 
+datas=[
+          ( '../annotator/menu.json', './annotator/' ),
+          ( '../plugins/menu.json', './plugins/' ),
+          ( '../icons/*', './icons/' ),
+          ( '../icons/Disabled/*', './icons/Disabled/' ),
+          ( '../segment/menu.json', './segment/' )
+      ]
 
-a = Analysis(['./../main.py'],
-             pathex=pathex,
-             binaries=[],
-             datas=[
-                      ( '../annotator/menu.json', './annotator/' ),
-                      ( '../plugins/menu.json', './plugins/' ),
-                      ( '../icons/*', './icons/' ),
-                      ( '../icons/Disabled/*', './icons/Disabled/' ),
-                      ( '../segment/menu.json', './segment/' )
-                    ],
-             hiddenimports=['scipy._lib.messagestream',
-                      'pywt._extensions._cwt',
-                      'PyQt5.sip',
-                      'numpy.core._dtype_ctypes',
-                      'gast'
-                      ],
-             hookspath=[],
-             runtime_hooks=[],
-             excludes=[],
-             win_no_prefer_redirects=False,
-             win_private_assemblies=False,
-             cipher=block_cipher)
-pyz = PYZ(a.pure, a.zipped_data,
-             cipher=block_cipher)
-exe = EXE(pyz,
-          a.scripts,
-          exclude_binaries=True,
-          name='main',
-          debug=False,
-          strip=False,
-          upx=True,
-          console=True )
-coll = COLLECT(exe,
-               a.binaries,
-               a.zipfiles,
-               a.datas,
-               strip=False,
-               upx=True,
-               name='main')
+hiddenimports=['scipy._lib.messagestream',
+               'pywt._extensions._cwt',
+               'PyQt5.sip',
+               'numpy.core._dtype_ctypes',
+               'gast'
+              ]
+
+coll += analysis(['./../main.py'], pathex, datas, hiddenimports, 'main')
+
+
+
+########################## train ##########################
+pathex=[]
+for dirpath, dirnames, filenames in os.walk( path.join(main_dir, "segment","_3D_FFN","ffn") ):
+    if os.path.basename(dirpath) != '__pycache__':
+            pathex.append(path.join(main_dir, "segment", dirpath))
+
+translate=[path.join(main_dir, "segment","_3D_FFN","ffn","train.py")]
+hiddenimports=['scipy._lib.messagestream','pywt._extensions._cwt','gast','astor','termcolor','google.protobuf.wrappers_pb2','tensorflow.contrib']
+
+coll += analysis(translate, pathex, [], hiddenimports, 'train')
+
+
+
+########################## run_inference_win ##########################
+pathex=[]
+for dirpath, dirnames, filenames in os.walk( path.join(main_dir, "segment","_3D_FFN","ffn") ):
+    if os.path.basename(dirpath) != '__pycache__':
+            pathex.append(path.join(main_dir, "segment", dirpath))
+
+translate=[path.join(main_dir, "segment","_3D_FFN","ffn","run_inference_win.py")]
+hiddenimports=['scipy._lib.messagestream','pywt._extensions._cwt','PyQt5.sip','gast','astor','termcolor','google.protobuf.wrappers_pb2','tensorflow.contrib']
+
+coll += analysis(translate, pathex, [], hiddenimports, 'run_inference_win')
+
+
+
+########################## build_coordinates ##########################
+pathex=[]
+for dirpath, dirnames, filenames in os.walk( path.join(main_dir, "segment","_3D_FFN","ffn") ):
+    if os.path.basename(dirpath) != '__pycache__':
+            pathex.append(path.join(main_dir, "segment", dirpath))
+
+translate=[path.join(main_dir, "segment","_3D_FFN","ffn","build_coordinates.py")]
+hiddenimports=['scipy._lib.messagestream','pywt._extensions._cwt','tensorflow.contrib']
+
+coll += analysis(translate, pathex, [], hiddenimports, 'build_coordinates')
+
+
+
+########################## compute_partitions ##########################
+pathex=[]
+for dirpath, dirnames, filenames in os.walk( path.join(main_dir, "segment","_3D_FFN","ffn") ):
+    if os.path.basename(dirpath) != '__pycache__':
+            pathex.append(path.join(main_dir, "segment", dirpath))
+
+translate=[path.join(main_dir, "segment","_3D_FFN","ffn","compute_partitions.py")]
+hiddenimports=['scipy._lib.messagestream','pywt._extensions._cwt','tensorflow.contrib']
+
+coll += analysis(translate, pathex, [], hiddenimports, 'compute_partitions')
+
+
+
+########################## tensorboard ##########################
+import tensorboard as _
+WEBFILES = os.path.join(_.__path__[0], "webfiles.zip")
+
+tensorb=[path.join(main_dir, "segment","tensorboard","tensorb.py")]
+pathex=[]
+
+datas=[ ( WEBFILES, './tensorboard/' ) ]
+hiddenimports=['scipy._lib.messagestream','pywt._extensions._cwt','tensorflow.contrib']
+
+coll += analysis(tensorb, pathex, datas, hiddenimports, 'tensorb')
+
+
+
+########################## translate ##########################
+pathex=[path.join(main_dir, "segment","_2D_DNN")]
+translate=[path.join(main_dir, "segment","_2D_DNN","translate.py")]
+
+hiddenimports=['scipy._lib.messagestream','pywt._extensions._cwt','tensorflow.contrib']
+
+coll += analysis(tensorb, pathex, [], hiddenimports, 'translate')
+
+
+
+######### All Collect #########
+print('### Collect All resources ###')
+coll_all = COLLECT(*coll, strip=False, upx=True, name='main')


### PR DESCRIPTION
## Overview
  - In order to unify a common resource for the capacity reduction, it outputs to one place by the `COLLECT` of Pyinstaller.
  -By the following command, it is together put to  directory `dist\main`. 
    ```
    pyinstaller --debug all --noconfirm --clean specs\main_.spec
    ```