### PR TITLE
Feature/inspect qtweb white screen

### DIFF
--- a/gui/func_persephonep.py
+++ b/gui/func_persephonep.py
@@ -31,6 +31,10 @@ QProgressBar::chunk {
 }
 """
 
+class WebPageWithJSConsole(QWebEnginePage):
+    def javaScriptConsoleMessage(self, page, msg, line, source):
+        print('%s line %d: %s' % (source, line, msg))
+
 ''' This is a single page of the browser.
     This class equals a tab of PersephonepTableWidget.
     This class can run only this python script, however,
@@ -48,9 +52,12 @@ class PersephonepWindow(QWidget):
 
         # config
         # initurl = 'https://www.google.co.jp'
-        
+
         # setting window
         self.window = QWebEngineView()
+
+        # Set WebPage with output javascript console.
+        self.window.setPage(WebPageWithJSConsole(self.window))
 
         proxy = QNetworkProxy()
         proxy.setType(QNetworkProxy.NoProxy)

--- a/main.py
+++ b/main.py
@@ -19,6 +19,10 @@ from MainWindow import MainWindow
 
 if __name__ == '__main__':
 
+    # For QtWebEngine gpu problems and enable QtWebEngine debug mode.
+    os.environ['QTWEBENGINE_CHROMIUM_FLAGS'] = '--disable-gpu'
+    os.environ['QTWEBENGINE_REMOTE_DEBUGGING'] = '9999'
+
     app = QApplication(sys.argv)
     ex = MainWindow()
     sys.exit(app.exec_())


### PR DESCRIPTION
**※For issue inspect code**

## Add feature.
  - Pass command line arguments '--disable-gpu' to Chromium.
  - Enable Chromium devTools function.
    - Start QtWebEngine and, In another browser, connect to `http://127.0.0.1:9999` , then show devTools page.