### PR TITLE
Fix asyncio event loop problem.

### DIFF
--- a/dojo/DojoServer.py
+++ b/dojo/DojoServer.py
@@ -108,7 +108,8 @@ class ServerLogic:
     # running live
 
     ####
-    asyncio.set_event_loop(u_info.worker_loop)
+    ev_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(ev_loop)
 
     dojo = tornado.web.Application([
       (r'/dojo/gfx/(.*)', tornado.web.StaticFileHandler, {'path': path_gfx}),
@@ -128,6 +129,8 @@ class ServerLogic:
     print('*'*80)
 
     tornado.ioloop.IOLoop.instance().start()
+    ev_loop.stop()
+    ev_loop.close()
     server.stop()
 
     # def sig_handler(signum, frame):

--- a/gui/DojoFileIO.py
+++ b/gui/DojoFileIO.py
@@ -64,15 +64,15 @@ class DojoFileIO():
     def RestartDojo(self):
 
         print("Asked tornado to exit\n")
-        self.u_info.worker_loop.stop()
+        #self.u_info.worker_loop.stop()
         time.sleep(1)
-        self.u_info.worker_loop.close()
+        #self.u_info.worker_loop.close()
 
         time.sleep(1)
         print('Restart dojo server.')
         self.u_info.port = self.u_info.port + 1
         print('Port Num: ', self.u_info.port)
-        self.u_info.worker_loop = asyncio.new_event_loop()
+        #self.u_info.worker_loop = asyncio.new_event_loop()
         self.u_info.dojo_thread = threading.Thread(target=self.StartThreadDojo)
         self.u_info.dojo_thread.setDaemon(True) # Stops if control-C
         self.u_info.dojo_thread.start()
@@ -85,9 +85,9 @@ class DojoFileIO():
     def TerminateDojo(self):
         print("Asked tornado to exit\n")
         # Python3
-        self.u_info.worker_loop.stop()
-        time.sleep(1)
-        self.u_info.worker_loop.close()
+        #self.u_info.worker_loop.stop()
+        #time.sleep(1)
+        #self.u_info.worker_loop.close()
         #self.u_info.worker_loop.stop()
         #self.u_info.worker_loop.call_soon_threadsafe(self.u_info.worker_loop.close)
         #self.u_info.dojo_thread.join()
@@ -108,7 +108,7 @@ class DojoFileIO():
         # Python3
         self.u_info.port = self.u_info.port + 1
         print('Port Num: ', self.u_info.port)
-        self.u_info.worker_loop = asyncio.new_event_loop()
+        #self.u_info.worker_loop = asyncio.new_event_loop()
         self.u_info.dojo_thread = threading.Thread(target=self.StartThreadDojo)
         self.u_info.dojo_thread.setDaemon(True) # Stops if control-C
         self.u_info.dojo_thread.start()

--- a/gui/MainWindow.py
+++ b/gui/MainWindow.py
@@ -271,8 +271,7 @@ class PersephonepTableWidget(QWidget):
                 print('Error ocurred in closing tensorboard.')
                 return
         ###
-        # self.tab.pop(index).close() Error ocurrs when a tab is re-launched.
-        self.tab.pop(index)
+        self.tab.pop(index).close()
         appl = self.appl.pop(index)
         self.tabs.removeTab(index)
 


### PR DESCRIPTION
## Fix overview
  - The default event loop of python asyncio exists only one in current thread.
  - Not set external `new_event_loop` but modified  creating `new_event_loop` in self context.
  - Restore closing tab.